### PR TITLE
Fix adding empty learner name

### DIFF
--- a/client/cypress/integration/learner-list.spec.ts
+++ b/client/cypress/integration/learner-list.spec.ts
@@ -103,7 +103,10 @@ describe('Learner list view',()=>{
 
     cy.get<HTMLButtonElement>('[data-test=addLearnerButton]').click();
 
-    cy.get('.mat-simple-snackbar').should('contain.text','Failed to add a new Learner');
+    it('should have an error message for an empty name', () => {
+      expect(page.addLearner('')).should('contain.text','Unable to add a Learner without a valid name');
+    });
+    // cy.get(page.addLearner('')).should('contain.text','Unable to add a Learner without a valid name');
   });
 
   it('Should list assigned words', () => {

--- a/client/cypress/integration/learner-list.spec.ts
+++ b/client/cypress/integration/learner-list.spec.ts
@@ -136,7 +136,7 @@ describe('Learner list view',()=>{
     disabledWordlists.should('contain.text','k');
     // checking the box should add the wordlist to enabled list
     // and remove from disabled
-    cy.get('.toggle-list-assign input').eq(1).should('not.be.checked');
+    cy.get('.toggle-list-assign input').eq(1).should('not.be.checked').wait(1000);
     cy.get('.toggle-list-assign input').eq(1).click({force:true});
     cy.get('.toggle-list-assign input').eq(1).should('be.checked');
     // only the correct wordlist should be reomved from the list

--- a/client/src/app/learners/learner-list/learner-list.component.html
+++ b/client/src/app/learners/learner-list/learner-list.component.html
@@ -52,7 +52,7 @@
           <form [formGroup]="learnerForm" class="newLearnerForm">
             <mat-form-field class="learnerName-field">
               <mat-label>Enter New Learner's Name</mat-label>
-              <input formControlName="name" required matInput data-test="newLearnerNameInput" placeholder="New Learner's Name">
+              <input autocomplete="off" formControlName="name" required matInput data-test="newLearnerNameInput" placeholder="New Learner's Name">
               <mat-error class="error-message" data-test="nameError">Please enter a valid name</mat-error>
            </mat-form-field>
           </form>

--- a/client/src/app/learners/learner-list/learner-list.component.html
+++ b/client/src/app/learners/learner-list/learner-list.component.html
@@ -53,6 +53,7 @@
             <mat-form-field class="learnerName-field">
               <mat-label>Enter New Learner's Name</mat-label>
               <input formControlName="name" required matInput data-test="newLearnerNameInput" placeholder="New Learner's Name">
+              <mat-error class="error-message" data-test="nameError">Please enter a valid name</mat-error>
            </mat-form-field>
           </form>
           <button mat-icon-button data-test="addLearnerButton" class="addLearnerButton" matTooltip="Submit New Learner" matTooltipPosition="above" (click)="submitForm()"><mat-icon>add</mat-icon></button>

--- a/client/src/app/learners/learner.service.spec.ts
+++ b/client/src/app/learners/learner.service.spec.ts
@@ -96,6 +96,52 @@ describe('LearnerService', () => {
       expect(service.checkIfLoggedIn('false')).toEqual(false);
     });
 
+    it('addLearner() should not accept an empty name', () => {
+      const noName: Learner =  {
+        _id: 'noNameId',
+        creator: 'KK',
+        name: '',
+        assignedContextPacks: ['oneId','twoId','threeId'],
+        disabledWordlists: ['wordlistName1','wordlistName2','wordlistName3'],
+      };
+      expect(service.addLearner(noName)).toBeFalsy();
+    });
+
+    it('addLearner() should not accept a name of just spaces', () => {
+      const spaceName: Learner =  {
+        _id: 'spaceNameId',
+        creator: 'KK',
+        name: '               ',
+        assignedContextPacks: ['oneId','twoId','threeId'],
+        disabledWordlists: ['wordlistName1','wordlistName2','wordlistName3'],
+      };
+      expect(service.addLearner(spaceName)).toBeFalsy();
+    });
+
+    it('addLearner() should accept the name David', () => {
+      const david: Learner =  {
+        _id: 'test',
+        creator: 'KK',
+        name: 'David',
+        assignedContextPacks: ['oneId','twoId','threeId'],
+        disabledWordlists: ['wordlistName1','wordlistName2','wordlistName3'],
+      };
+
+      expect(service.addLearner(david)).toBeTruthy();
+    });
+
+    it('addLearner() should accept a name surrounded by spaces', () => {
+      const spaceDavid: Learner =  {
+        _id: 'spaceDavidId',
+        creator: 'KK',
+        name: '     David        ',
+        assignedContextPacks: ['oneId','twoId','threeId'],
+        disabledWordlists: ['wordlistName1','wordlistName2','wordlistName3'],
+      };
+
+      expect(service.addLearner(spaceDavid)).toBeTruthy();
+    });
+
     it('addLeaner() posts to api/learners', () => {
 
       service.addLearner(testLearners[1]).subscribe(

--- a/client/src/app/learners/learner.service.ts
+++ b/client/src/app/learners/learner.service.ts
@@ -70,7 +70,10 @@ export class LearnerService {
   }
 
   addLearner(newLearner: Learner): Observable<string>{
-    return this.httpClient.post<{id: string}>(this.learnerUrl, newLearner).pipe(map(res => res.id));
+    if (newLearner.name.length > 0)
+    {return this.httpClient.post<{id: string}>(this.learnerUrl, newLearner).pipe(map(res => res.id));}
+    else
+    {alert('Unable to add learner with an empty name'); };
   }
 
 }

--- a/client/src/app/learners/learner.service.ts
+++ b/client/src/app/learners/learner.service.ts
@@ -70,10 +70,11 @@ export class LearnerService {
   }
 
   addLearner(newLearner: Learner): Observable<string>{
-    if (newLearner.name.length > 0)
+    const learnerName = newLearner.name.trim();
+    if (learnerName.length > 0)
     {return this.httpClient.post<{id: string}>(this.learnerUrl, newLearner).pipe(map(res => res.id));}
     else
-    {alert('Unable to add learner with an empty name'); };
+    {alert('Unable to add learner without a valid name'); };
   }
 
 }


### PR DESCRIPTION
Updates the learner.service so that a learner with an empty name can no longer be added. 
closes issue #37 